### PR TITLE
Translations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,13 +55,13 @@ const App: React.FC<Props> = props => {
 
   const renderFlagButton = (
     flagImage: string,
-    twoLetterCode: string,
+    letterCode: string,
     languageFull: string
   ) => {
     return (
       <div
         className="langFlag"
-        onClick={() => handleChangeLanguage(twoLetterCode)}>
+        onClick={() => handleChangeLanguage(letterCode)}>
         <img src={flagImage} alt={languageFull} title={languageFull} />
       </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,14 +10,14 @@ import messages_nl from "./translations/nl.json";
 import messages_es from "./translations/es.json";
 import messages_pt from "./translations/pt.json";
 import messages_de from "./translations/de.json";
-// import messages_at from "./translations/at.json";
+import messages_at from "./translations/at.json";
 // import messages_ro from "./translations/ro.json";
 import EnglishFlag from "./images/flags/uk.svg";
 import DutchFlag from "./images/flags/nl.svg";
 import SpanishFlag from "./images/flags/es.svg";
 import PortugueseFlag from "./images/flags/pt.svg";
 import GermanFlag from "./images/flags/de.svg";
-// import AustrianFlag from "./images/flags/at.svg";
+import AustrianFlag from "./images/flags/at.svg";
 // import RomanianFlag from "./images/flags/ro.svg";
 import { connect } from "react-redux";
 import { Question } from "./types/question";
@@ -31,8 +31,8 @@ const messages: any = {
   nl: messages_nl,
   es: messages_es,
   pt: messages_pt,
-  de: messages_de
-  // at: messages_at,
+  "de-DE": messages_de,
+  "de-AT": messages_at
   // ro: messages_ro,
 };
 
@@ -47,6 +47,7 @@ const App: React.FC<Props> = props => {
   const handleChangeLanguage = (newLanguage: string): void => {
     setLanguage(newLanguage);
   };
+
   useEffect(() => {
     setAllQuestions(messages[language].questions);
     setAllAnswers(messages[language].answers);
@@ -79,8 +80,8 @@ const App: React.FC<Props> = props => {
           {renderFlagButton(EnglishFlag, "en", "English")}
           {renderFlagButton(SpanishFlag, "es", "Spanish")}
           {renderFlagButton(PortugueseFlag, "pt", "Portuguese")}
-          {renderFlagButton(GermanFlag, "de", "German")}
-          {/* {renderFlagButton(AustrianFlag, "at", "Austrian German")} */}
+          {renderFlagButton(GermanFlag, "de-DE", "German")}
+          {renderFlagButton(AustrianFlag, "de-AT", "Austrian German")}
           {/* {renderFlagButton(RomanianFlag, "ro", "Romanian")} */}
         </div>
       </div>

--- a/src/images/flags/fr.svg
+++ b/src/images/flags/fr.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<circle style="fill:#F0F0F0;" cx="256" cy="256" r="256"/>
+<path style="fill:#D80027;" d="M512,256c0-110.071-69.472-203.906-166.957-240.077v480.155C442.528,459.906,512,366.071,512,256z"/>
+<path style="fill:#0052B4;" d="M0,256c0,110.071,69.473,203.906,166.957,240.077V15.923C69.473,52.094,0,145.929,0,256z"/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/src/translations/at.json
+++ b/src/translations/at.json
@@ -1,0 +1,90 @@
+{
+  "app.title": "Servas bei Should-I-Go-Out?",
+  "app.startButton": "I will raus, aba is des gscheid?",
+  "app.nextQuestionButton": "Weiter",
+  "app.retryButton": "No amoi",
+  "app.redirectToHome": "Zrück zum Start",
+  "app.noAnswerError": "Du musst dir eine Antwort aussuchen",
+  "questions": [
+    {
+      "questionNumber": 1,
+      "question": "Gehst hackeln?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 2,
+      "question": "Gehst Essen einkaufen?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 3,
+      "question": "Gehst zum Apotheker?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 4,
+      "question": "Gehst spazieren?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 5,
+      "question": "Gehst allan oder mit Leuten mit denenst zamwohnst raus?",
+      "answers": [
+        "ja, allan oder mit Leuten mit denen ich zamwohn",
+        "na, mit anderen Leuten"
+      ]
+    },
+    {
+      "questionNumber": 6,
+      "question": "Willst an kranken Hawerer helfen?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 7,
+      "question": "Muass das jetzt sein?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 8,
+      "question": "Ist dei Hackn überlebensnotwendig für die Leitl?",
+      "answers": ["ja", "na"]
+    },
+    {
+      "questionNumber": 9,
+      "question": "Kannst von daham hackeln?",
+      "answers": ["ja", "na"]
+    }
+  ],
+  "answers": {
+    "stayIn": {
+      "id": 1,
+      "conclusion": "Bleib zaus.",
+      "explanation": "Du hast kan guatn Grund raus zu gehen. Du bringst dich selbst und andere in Gefahr, wennst rausgehst. Also bleib daham!"
+    },
+    "youHero": {
+      "id": 2,
+      "conclusion": "Worauf wartest, geh raus!",
+      "explanation": "Dei Hackn is überlebensnotwenig für die Gsellschaft. Danke und weiter so!"
+    },
+    "youShouldKnowBetter": {
+      "id": 3,
+      "conclusion": "I dadat ned rausgehn.",
+      "explanation": "Dein Chef sollte dir erlauben von zu Hause zu arbeiten. Du bringst dich selbst und andere in Gefahr, wennst rausgehst. Wennst doch beschließst rauszugehen, halt Abstand zu anderen, zumindest 1,5 Meter."
+    },
+    "caretaker": {
+      "id": 4,
+      "conclusion": "Du kannst vorsichtig rausgehen.",
+      "explanation": "Kümmer dich gut um deinen Hawerer. Geh allein und halt zumindest 1,5 Meter Abstand zu anderen. Halt dich an die Hygienevorschriften, damitst nicht selbst krank wirst."
+    },
+    "goAlone": {
+      "id": 5,
+      "conclusion": "Du kannst vorsichtig rausgehen.",
+      "explanation": "Du kannst kurz rausgehen, mach was du machen musst. Geh allein und halt zumindest 1,5 Meter Abstand zu anderen. Wenn andere dir zu nahe kommen, sags ihnen und bitte sie Abstand zu halten. Dadurch beschützt du sie und dich selbst."
+    },
+    "avoidOthers": {
+      "id": 6,
+      "conclusion": "Du kannst vorsichtig rausgehen.",
+      "explanation": "Du kannst kurz rausgehen. Halt 1,5 Meter Abstand zu anderen. Wenn andere dir zu nahe kommen, sags ihnen und bitte sie darum Abstand zu halten. Dadurch beschützt du sie und dich selbst."
+    }
+  }
+}

--- a/src/translations/pos-neg-answers.ts
+++ b/src/translations/pos-neg-answers.ts
@@ -9,7 +9,8 @@ export const positiveAnswers: PositiveNegativeAnswers = [
   "ja, alleen of alleen met mensen die bij je in huis wonen",
   "si, solo o con las personas que vivo",
   "sim, sozinho ou com pessoas com quem vivo",
-  "ja, alleine oder mit Leuten mit denen ich zusammenwohne"
+  "ja, alleine oder mit Leuten mit denen ich zusammenwohne",
+  "ja, allan oder mit Leuten mit denen ich zamwohn"
 ];
 
 export const negativeAnswers: string[] = [
@@ -17,9 +18,11 @@ export const negativeAnswers: string[] = [
   "nee",
   "não",
   "nein",
+  "na",
   "no, with others",
   "nee, ook met andere mensen",
   "no, con mas gente",
   "não, vou sair com outras pessoas",
-  "nein, mit anderen Leuten"
+  "nein, mit anderen Leuten",
+  "na, mit anderen Leuten"
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext",
+      "esnext.intl",
+      "es2017.intl",
+      "es2018.intl"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Add Austrian German as a language. 
Also, specify the German languages with 4 letter codes, rather than 2 letter codes, to indicate the dialects.
- For German "de-DE" instead of "de",
- For Austrian German "de-AT" instead of "at".

I have changed this, because "at" is not an official language code. This will throw errors in React-intl. 